### PR TITLE
Implement FAST Consent Operations

### DIFF
--- a/docker/fastconsentr4/DockerCommands.txt
+++ b/docker/fastconsentr4/DockerCommands.txt
@@ -1,17 +1,17 @@
 # -------------------------------------------------------------------------------
-# Set up named compose project fastconsentr4-wildfly-mysql80
+# Set up named compose project fastconsentri
 # - This will show up in Docker Desktop
 # - Uses compose.yaml in current directory/folder
 # -------------------------------------------------------------------------------
-docker compose -p fastconsentr4-wildfly-mysql80 create
+docker compose -p fastconsentri create
 
 =================================================================================
 
 # -------------------------------------------------------------------------------
-# Create docker bridge network fastconsentr4-net
+# Create docker bridge network fastconsentri-net
 # - This is needed for container-container communication
 # -------------------------------------------------------------------------------
-docker network create -d bridge fastconsentr4-net
+docker network create -d bridge fastconsentri-net
 
 # -------------------------------------------------------------------------------
 # Create and run wildfhirce-mysql image
@@ -19,25 +19,25 @@ docker network create -d bridge fastconsentr4-net
 # - Using the bridge network fastconsentr4-net
 # - Expose port 3306 for MySQL Workbench access
 # -------------------------------------------------------------------------------
-docker run --network=fastconsentr4-net -itd -p 3306:3306 --name=fastconsentr4-mysql80 aegisnetinc/fastconsentr4-mysql80:0.1.0
+docker run --network=fastconsentri-net -itd -p 3306:3306 --name=consent-management-db hlseven/consent-management-db:0.1.0
 
 # -------------------------------------------------------------------------------
-# Run fastconsentr4-mysql80 container
-# - Uses fastconsentr4-mysql80 container created from run command above
+# Run consent-management-db container
+# - Uses consent-management-db container created from run command above
 # -------------------------------------------------------------------------------
-docker start fastconsentr4-mysql80
+docker start consent-management-db
 
 # -------------------------------------------------------------------------------
-# Create and run fastconsentr4-wildfly image
+# Create and run consent-management-server image
 # - From tag 0.1.0
-# - Using the bridge network fastconsentr4-net
+# - Using the bridge network fastconsentri-net
 # - Define WildFHIR environment variable file
-# - Expose ports 80, 443, 9990 for browser and RESTful client access
+# - Expose ports 8080, 8443, 9990 for browser and RESTful client access
 # -------------------------------------------------------------------------------
-docker run --network=fastconsentr4-net -itd -p 80:80 -p 443:443 -p 9990:9990 --env-file env.list --name=fastconsentr4-wildfly aegisnetinc/fastconsentr4-wildfly:0.1.0
+docker run --network=fastconsentri-net -itd -p 8080:8080 -p 8443:8443 -p 9990:9990 --env-file env.list --name=consent-management-server hlseven/consent-management-server:0.1.0
 
 # -------------------------------------------------------------------------------
-# Run fastconsentr4-wildfly container
-# - Uses fastconsentr4-wildfly container created from run command above
+# Run consent-management-server container
+# - Uses consent-management-server container created from run command above
 # -------------------------------------------------------------------------------
-docker start fastconsentr4-wildfly
+docker start consent-management-server

--- a/docker/fastconsentr4/compose.yaml
+++ b/docker/fastconsentr4/compose.yaml
@@ -1,27 +1,28 @@
 services:
-  fastconsentr4-mysql80:
-    image: aegisnetinc/fastconsentr4-mysql80:0.1.0
-    container_name: fastconsentr4-mysql80
-    hostname: fastconsentr4-mysql80
+  consent-management-db:
+    image: hlseven/consent-management-db:0.1.0
+    container_name: consent-management-db
+    hostname: consent-management-db
     ports:
       - "3306:3306"
     volumes:
-      - fastconsentr4-mysql80-data:/var/lib/mysql
+      - consent-management-db-data:/var/lib/mysql
 
-  fastconsentr4-wildfly:
-    image: aegisnetinc/fastconsentr4-wildfly:0.1.0
+  consent-management-server:
+    image: hlseven/consent-management-server:0.1.0
     environment:
+#      - WILDFHIR_HOSTNAME=hostname - SET TO EXTERNAL HOSTNAME IF NEEDED
       - WILDFHIR_RESOURCEPURGEALLENABLED=true
-      - WILDFHIR_DATABASE_HOST=fastconsentr4-mysql80
-      - FHIR_PACKAGES=hl7.fhir.us.core#6.1.0
-    container_name: fastconsentr4-wildfly
-    hostname: fastconsentr4-wildfly
+      - WILDFHIR_DATABASE_HOST=consent-management-db
+      - FHIR_PACKAGES=hl7.fhir.us.consent-management#0.1.0
+    container_name: consent-management-server
+    hostname: consent-management-server
     ports:
       - "8080:8080"
       - "8443:8443"
       - "9990:9990"
     depends_on:
-      - fastconsentr4-mysql80
+      - consent-management-db
 
 volumes:
-  fastconsentr4-mysql80-data:
+  consent-management-db-data:

--- a/docker/fastconsentr4/fastconsentr4-mysql80/DockerCommands.txt
+++ b/docker/fastconsentr4/fastconsentr4-mysql80/DockerCommands.txt
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Build fastconsentr4-mysql80 image
+# Build consent-management-db image
 # - Named tag 0.1.0
 # -------------------------------------------------------------------------------
-docker build -t aegisnetinc/fastconsentr4-mysql80:0.1.0 .
+docker build -t hlseven/consent-management-db:0.1.0 .

--- a/docker/fastconsentr4/fastconsentr4-wildfly/DockerCommands.txt
+++ b/docker/fastconsentr4/fastconsentr4-wildfly/DockerCommands.txt
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Build fastconsentr4-wildfly image
+# Build consent-management-server image
 # - Named tag 0.1.0
 # -------------------------------------------------------------------------------
-docker build -t aegisnetinc/fastconsentr4-wildfly:0.1.0 .
+docker build -t hlseven/consent-management-server:0.1.0 .

--- a/source/wildfhir-model/src/main/java/net/aegis/fhir/model/ResourceType.java
+++ b/source/wildfhir-model/src/main/java/net/aegis/fhir/model/ResourceType.java
@@ -903,6 +903,10 @@ public class ResourceType {
 
 		operationList = new ArrayList<LabelKeyValueBean>();
 		operationList.addAll(baseOperationList);
+		operationList.add(new LabelKeyValueBean("fileConsent", "consent", "http://hl7.org/fhir/us/consent-management/OperationDefinition/file-consent", "write"));
+		operationList.add(new LabelKeyValueBean("recordDisclosure", "consent", "http://hl7.org/fhir/us/consent-management/OperationDefinition/record-disclosure", "write"));
+		operationList.add(new LabelKeyValueBean("revokeConsent", "consent", "http://hl7.org/fhir/us/consent-management/OperationDefinition/revoke-consent", "write"));
+		operationList.add(new LabelKeyValueBean("updateConsent", "consent", "http://hl7.org/fhir/us/consent-management/OperationDefinition/update-consent", "write"));
 		resourceOperations.put("Consent", operationList);
 
 		operationList = new ArrayList<LabelKeyValueBean>();

--- a/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/ResourceOperationsRESTService.java
+++ b/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/ResourceOperationsRESTService.java
@@ -66,6 +66,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.UTCDateUtil;
 
@@ -97,10 +99,16 @@ public class ResourceOperationsRESTService {
 	private Logger log;
 
 	@Inject
+	AuditEventService auditEventService;
+
+	@Inject
 	BatchService batchService;
 
 	@Inject
     CodeService codeService;
+
+	@Inject
+    ProvenanceService provenanceService;
 
 	@Inject
     ResourceService resourceService;
@@ -464,7 +472,7 @@ public class ResourceOperationsRESTService {
 
 					String softwareVersion = ServicesUtil.INSTANCE.getSoftwareVersion();
 					log.fine("softwareVersion: " + softwareVersion);
-					Parameters outputParameters = operationProxy.executeOperation(context, headers, resourceService, resourcemetadataService, batchService, transactionService, codeService, conformanceService, softwareVersion, resourceType, resourceId, inputParameters, inputResource, payload, contentType, isPost, returnedDirective);
+					Parameters outputParameters = operationProxy.executeOperation(context, headers, resourceService, resourcemetadataService, batchService, transactionService, codeService, auditEventService, provenanceService, conformanceService, softwareVersion, resourceType, resourceId, inputParameters, inputResource, payload, contentType, isPost, returnedDirective);
 
 					String locationPath = context.getPath();
 

--- a/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/ResourceRESTService.java
+++ b/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/ResourceRESTService.java
@@ -357,7 +357,7 @@ public class ResourceRESTService {
 
 		Response response = null;
 
-		debugRequest(request, headers, null);
+		debugRequest(request, headers, resourceInputStream, null, false);
 
 		try {
 			// Validate request fhir version with supported fhir version
@@ -855,7 +855,6 @@ public class ResourceRESTService {
 			}
 		}
 
-		log.info("----- PAYLOAD ----- [snipped; use fine logging]");
 		if (resourceInputStream != null) {
 			try {
 				StringWriter writer = new StringWriter();
@@ -864,10 +863,11 @@ public class ResourceRESTService {
 				payload = writer.toString();
 
 				if (snipped == false) {
+					log.info("----- PAYLOAD -----");
 					log.info(payload);
 				}
 				else {
-					log.fine(">> SNIPPED <<");
+					log.info("----- PAYLOAD ----- [snipped]");
 				}
 
 			}

--- a/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/init/InitializeCapabilityStatement.java
+++ b/source/wildfhir-rest-server/src/main/java/net/aegis/fhir/rest/init/InitializeCapabilityStatement.java
@@ -106,7 +106,7 @@ public class InitializeCapabilityStatement extends HttpServlet {
 				ResourceOperationProxy operationProxy = operationFactory.getResourceOperationProxy(null, "capability-reload");
 
 				if (operationProxy != null) {
-					Parameters outputParameters = operationProxy.executeOperation(null, null, null, null, null, null, codeService, conformanceService, softwareVersion, null, null, null, null, null, null, false, null);
+					Parameters outputParameters = operationProxy.executeOperation(null, null, null, null, null, null, codeService, null, null, conformanceService, softwareVersion, null, null, null, null, null, null, false, null);
 
 					if (outputParameters != null) {
 						if (!outputParameters.hasParameter()) {

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CapabilityStatementReload.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CapabilityStatementReload.java
@@ -81,7 +81,9 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 
 public class CapabilityStatementReload extends ResourceOperationProxy {
@@ -102,10 +104,10 @@ public class CapabilityStatementReload extends ResourceOperationProxy {
 	}
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
         log.fine("CapabilityStatementReload.executeOperation() - [START] ");
 
@@ -125,7 +127,7 @@ public class CapabilityStatementReload extends ResourceOperationProxy {
 					baseUrl = codeService.getCodeValue("baseUrl");
 					if (baseUrl == null || baseUrl.isEmpty()) {
 						// Default base url with localhost
-						baseUrl = "http://localhost/r4";
+						baseUrl = "http://localhost:8080/r4";
 					}
 				}
 				// Update base url with current hostname
@@ -134,13 +136,13 @@ public class CapabilityStatementReload extends ResourceOperationProxy {
 						// Get local hostname
 						String hostname = ServicesUtil.INSTANCE.getHostName();
 						if (hostname != null && !hostname.equals("locahost")) {
-							baseUrl = "http://" + hostname + "/r4";
+							baseUrl = "http://" + hostname + ":8080/r4";
 						}
 					}
 				}
 				catch (Exception e) {
 					// Default base url with localhost
-					baseUrl = "http://localhost/r4";
+					baseUrl = "http://localhost:8080/r4";
 				}
 
 				boolean capStatementLoaded = reloadCapabilityStatement(conformanceService, softwareVersion, baseUrl, baseCapStmt);
@@ -235,33 +237,45 @@ public class CapabilityStatementReload extends ResourceOperationProxy {
 			capabilityStatementResource.setText(null);
 			capabilityStatementResource.setUrl(baseUrl + "/metadata");
 			capabilityStatementResource.setVersion(softwareVersion);
-			capabilityStatementResource.setName("AEGISWildFHIR401");
-			capabilityStatementResource.setTitle("AEGIS WildFHIR Test Server FHIR R4");
+			if (!capabilityStatementResource.hasName()) {
+				capabilityStatementResource.setName("AEGISWildFHIR401");
+			}
+			if (!capabilityStatementResource.hasTitle()) {
+				capabilityStatementResource.setTitle("AEGIS WildFHIR Community Edition Test Server FHIR R4");
+			}
 			capabilityStatementResource.setStatus(PublicationStatus.ACTIVE);
-			capabilityStatementResource.setPublisher("AEGIS.net, Inc.");
-			capabilityStatementResource.getContact().clear();
-			ContactDetail contact = new ContactDetail();
-			ContactPoint telcom = new ContactPoint();
-			telcom.setSystem(ContactPointSystem.URL);
-			telcom.setValue(baseUrl);
-			contact.addTelecom(telcom);
-			capabilityStatementResource.addContact(contact);
-			capabilityStatementResource.setDescription("AEGIS WildFHIR Test Server supporting the HL7 FHIR R4 (v4.0.1-Official) specification.");
+			if (!capabilityStatementResource.hasPublisher()) {
+				capabilityStatementResource.setPublisher("AEGIS.net, Inc.");
+			}
+			if (!capabilityStatementResource.hasContact()) {
+				ContactDetail contact = new ContactDetail();
+				ContactPoint telcom = new ContactPoint();
+				telcom.setSystem(ContactPointSystem.URL);
+				telcom.setValue(baseUrl);
+				contact.addTelecom(telcom);
+				capabilityStatementResource.addContact(contact);
+			}
+			if (!capabilityStatementResource.hasDescription()) {
+				capabilityStatementResource.setDescription("AEGIS WildFHIR Community Edition Test Server supporting the HL7 FHIR R4 (v4.0.1-Official) specification.");
+			}
 			capabilityStatementResource.setKind(CapabilityStatementKind.INSTANCE);
 			DateTimeType publishDateTime = new DateTimeType();
 			publishDateTime.setTimeZoneZulu(true);
 			publishDateTime.setValue(new Date());
 			capabilityStatementResource.setDateElement(publishDateTime);
-			if (capabilityStatementResource.hasSoftware()) {
+			if (!capabilityStatementResource.hasSoftware()) {
 				capabilityStatementResource.getSoftware().setName("WildFHIR");
 				// Set software version from build properties
 				capabilityStatementResource.getSoftware().setVersion(softwareVersion);
 				capabilityStatementResource.getSoftware().setReleaseDate(publishDateTime.getValue());
 			}
-			CapabilityStatementImplementationComponent implementation = new CapabilityStatementImplementationComponent();
-			implementation.setDescription(capabilityStatementResource.getDescription());
-			capabilityStatementResource.setImplementation(implementation);
-			capabilityStatementResource.setFhirVersion(FHIRVersion._4_0_1);
+			if (!capabilityStatementResource.hasSoftware()) {
+				CapabilityStatementImplementationComponent implementation = new CapabilityStatementImplementationComponent();
+				implementation.setDescription(capabilityStatementResource.getDescription());
+				capabilityStatementResource.setImplementation(implementation);
+				capabilityStatementResource.setFhirVersion(FHIRVersion._4_0_1);
+			}
+
 			// Format and Patch Format already defined in base
 			//capabilityStatementResource.addPatchFormat("application/xml-patch+xml");
 			//capabilityStatementResource.addPatchFormat("application/json-patch+json");
@@ -283,6 +297,11 @@ public class CapabilityStatementReload extends ResourceOperationProxy {
 
 					for (CapabilityStatementRestResourceComponent restResource : rest.getResource()) {
 						log.fine("Working on ResourceType " + restResource.getType());
+
+						if (restResource.getType().equals("Parameters")) {
+							// Skip non-persisted Resource Types
+							continue;
+						}
 
 						// Set resource type interactions
 						if (restResource.hasInteraction()) {

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CodeConfiguration.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CodeConfiguration.java
@@ -54,7 +54,9 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 
 /**
@@ -68,10 +70,10 @@ public class CodeConfiguration extends ResourceOperationProxy {
 	private CodeService codeService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] CodeConfiguration.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CompositionDocument.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/CompositionDocument.java
@@ -80,9 +80,11 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.linked.LinkedResourceProxy;
 import net.aegis.fhir.service.linked.LinkedResourceProxyObjectFactory;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.UUIDUtil;
 //import net.aegis.fhir.service.validation.FHIRValidatorClient;
@@ -96,10 +98,10 @@ public class CompositionDocument extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("CompositionDocument");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] CompositionDocument.executeOperation()");
 
@@ -844,7 +846,10 @@ public class CompositionDocument extends ResourceOperationProxy {
 			searchParams.add("composition._id", composition.getId());
 
 			// Execute search query
-			List<net.aegis.fhir.model.Resource> resources = resourceService.searchQuery(searchParams, null, null, "Bundle", false, null, null, null, null, null);
+			List<String[]> validParams = new ArrayList<String[]>();
+			List<String[]> invalidParams = new ArrayList<String[]>();
+
+			List<net.aegis.fhir.model.Resource> resources = resourceService.searchQuery(searchParams, null, null, "Bundle", false, null, null, null, validParams, invalidParams);
 
 			log.info("CompositionDocument - existing document resources.size() = " + resources.size());
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentFileConsent.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentFileConsent.java
@@ -1,0 +1,376 @@
+/*
+ * #%L
+ * WildFHIR - wildfhir-model
+ * %%
+ * Copyright (C) 2024 AEGIS.net, Inc.
+ * All rights reserved.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *  - Neither the name of AEGIS nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package net.aegis.fhir.operation;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.Status;
+
+import org.hl7.fhir.r4.formats.XmlParser;
+import org.hl7.fhir.r4.formats.IParser.OutputStyle;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+
+import net.aegis.fhir.model.ResourceContainer;
+import net.aegis.fhir.service.BatchService;
+import net.aegis.fhir.service.CodeService;
+import net.aegis.fhir.service.ConformanceService;
+import net.aegis.fhir.service.ResourceService;
+import net.aegis.fhir.service.ResourcemetadataService;
+import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventActionEnum;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceActivityTypeEnum;
+import net.aegis.fhir.service.provenance.ProvenanceService;
+import net.aegis.fhir.service.util.ServicesUtil;
+
+/**
+ * FAST Consent RI - $fileConsent operation
+ * 
+ * @author richard.ettema
+ *
+ */
+public class FASTConsentFileConsent extends ResourceOperationProxy {
+
+	private Logger log = Logger.getLogger("FASTConsentFileConsent");
+
+	private AuditEventService auditEventService;
+	private CodeService codeService;
+	private ProvenanceService provenanceService;
+	private ResourceService resourceService;
+	private XmlParser xmlP;
+
+	/* (non-Javadoc)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 */
+	@Override
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+
+		log.info("[START] FASTConsentFileConsent.executeOperation()");
+
+		this.auditEventService = auditEventService;
+		this.codeService = codeService;
+		this.provenanceService = provenanceService;
+        this.resourceService = resourceService;
+
+		Parameters out = new Parameters();
+
+		try {
+			/*
+			 * If inputParameters is null, throw exception
+			 */
+			if (inputParameters == null) {
+				throw new Exception("$fileConsent failed. The input parameters contents were empty or null.");
+			}
+
+			/*
+			 * Extract the individual expected parameters
+			 * - consent - FASTConsent resource (required)
+			 * - document - FASTDocumentReference or FASTQuestionnaireResponse resource (optional)
+			 */
+			Consent paramConsent = null;
+			DocumentReference paramDocumentReference = null;
+			QuestionnaireResponse paramQuestionnaireResponse = null;
+
+			if (inputParameters != null && inputParameters.hasParameter()) {
+
+				for (ParametersParameterComponent parameter : inputParameters.getParameter()) {
+
+					if (parameter.getName() != null && parameter.getName().equals("consent") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("Consent")) {
+							paramConsent = (Consent) paramResource;
+						}
+					}
+
+					if (parameter.getName() != null && parameter.getName().equals("document") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("DocumentReference")) {
+							paramDocumentReference = (DocumentReference) paramResource;
+						}
+						else if (paramResource != null && paramResource.fhirType().equals("QuestionnaireResponse")) {
+							paramQuestionnaireResponse = (QuestionnaireResponse) paramResource;
+						}
+					}
+				}
+			}
+
+			/*
+			 * If the 'consent' input parameter is null, throw exception
+			 */
+			if (paramConsent == null) {
+				throw new Exception("$fileConsent failed. The 'consent' input parameter was not defined or its resource contents were empty or null.");
+			}
+
+			OperationOutcome rOutcome = performFileConsent(context, headers, paramConsent, paramDocumentReference, paramQuestionnaireResponse);
+
+			if (rOutcome == null) {
+				/*
+				 * Returned OperationOutcome is null, throw exception (should not happen)
+				 */
+				throw new Exception("$fileConsent failed. The attempt to file the Consent and/or supporting document resources produced a null outcome. Please verify the contents of the input payload.");
+			}
+
+			out = new Parameters();
+
+			ParametersParameterComponent parameter = new ParametersParameterComponent();
+			parameter.setName("return");
+			parameter.setResource(rOutcome);
+
+			out.addParameter(parameter);
+		}
+		catch (Exception e) {
+			// Throw exceptions back
+			e.printStackTrace();
+			throw new Exception("$fileConsent failed! Exception thrown: " + e.getMessage());
+		}
+
+		log.info("[END] FASTConsentFileConsent.executeOperation()");
+
+		return out;
+	}
+
+	/**
+	 * Create the Consent and optional supporting source document in the local repository.
+	 * 
+	 * @param consent
+	 * @param documentReference
+	 * @param questionnaireResponse
+	 * @return OperationOutcome
+	 * @throws Exception
+	 */
+	private OperationOutcome performFileConsent(UriInfo context, HttpHeaders headers, Consent consent, DocumentReference documentReference, QuestionnaireResponse questionnaireResponse) throws Exception {
+
+		log.info("[START] FASTConsentFileConsent.performFileConsent()");
+
+		OperationOutcome rOutcome = null;
+		List<OperationOutcomeIssueComponent> issues = new ArrayList<OperationOutcomeIssueComponent>();
+		OperationOutcomeIssueComponent issue = null;
+
+		boolean ok = true;
+		xmlP = new XmlParser();
+		xmlP.setOutputStyle(OutputStyle.PRETTY);
+		net.aegis.fhir.model.Resource createResource = null;
+		ResourceContainer resCon = null;
+		ByteArrayOutputStream oResource = null;
+		byte fileContent[] = null;
+		String baseUrl = null;
+		Reference sourceReference = null;
+		Integer sourceId = null;
+
+		try {
+			// Get server base url from code table configuration
+			baseUrl = codeService.getCodeValue("baseUrl");
+
+			// Create DocumentReference if present
+			if (documentReference != null) {
+				createResource = new net.aegis.fhir.model.Resource();
+
+				// Remove existing Resource.id
+				documentReference.setIdElement(null);
+
+				// Convert documentReference to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, documentReference, true);
+				fileContent = oResource.toByteArray();
+
+				createResource.setResourceType("DocumentReference");
+				createResource.setResourceContents(fileContent);
+
+				resCon = resourceService.create(createResource, null, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					sourceReference = new Reference();
+					sourceReference.setReference("DocumentReference/" + resCon.getResource().getResourceId());
+					if (documentReference.hasIdentifier()) {
+						sourceReference.setIdentifier(documentReference.getIdentifierFirstRep());
+					}
+					// Save internal resource primary key if needed for hard delete
+					sourceId = resCon.getResource().getId();
+					// Capture successful DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							sourceReference.getReference() + " successfully created.", null, "Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = true;
+				}
+				else {
+					// Capture failed DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to create consent source DocumentReference.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = false;
+				}
+			}
+			// Create QuestionnaireResponse if present
+			else if (questionnaireResponse != null) {
+				createResource = new net.aegis.fhir.model.Resource();
+
+				// Remove existing Resource.id
+				questionnaireResponse.setIdElement(null);
+
+				// Convert questionnaireResponse to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, questionnaireResponse, true);
+				fileContent = oResource.toByteArray();
+
+				createResource.setResourceType("QuestionnaireResponse");
+				createResource.setResourceContents(fileContent);
+
+				resCon = resourceService.create(createResource, null, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					sourceReference = new Reference();
+					sourceReference.setReference("QuestionnaireResponse/" + resCon.getResource().getResourceId());
+					if (questionnaireResponse.hasIdentifier()) {
+						sourceReference.setIdentifier(questionnaireResponse.getIdentifier());
+					}
+					// Save internal resource primary key if needed for hard delete
+					sourceId = resCon.getResource().getId();
+					// Capture successful QuestionnaireResponse create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							sourceReference.getReference() + " successfully created.", null, "Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = true;
+				}
+				else {
+					// Capture failed QuestionnaireResponse create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to create consent source QuestionnaireResponse.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = false;
+				}
+			}
+
+			if (ok == true) {
+				// Create Consent
+				createResource = new net.aegis.fhir.model.Resource();
+
+				// Remove existing Resource.id
+				consent.setIdElement(null);
+
+				// Set Consent.source if needed
+				if (sourceReference != null) {
+					consent.setSource(sourceReference);
+				}
+
+				// Convert consent to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, consent, true);
+				fileContent = oResource.toByteArray();
+
+				createResource.setResourceType("Consent");
+				createResource.setResourceContents(fileContent);
+
+				resCon = resourceService.create(createResource, null, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					// Create AuditEvent
+					auditEventService.createAuditEvent(context, headers, null, "Consent", true, resCon.getResource().getResourceId(), AuditEventActionEnum.CREATE.getCode());
+					// Create Provenance
+					provenanceService.createProvenance(context, headers, null, "Consent", "Consent/" + resCon.getResource().getResourceId(), null, ProvenanceActivityTypeEnum.CREATE.getCode());
+
+					// Capture successful DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							"Consent/" + resCon.getResource().getResourceId() + " successfully created.", null, "Parameters.parameter.where(name = 'consent')");
+					issues.add(issue);
+				}
+				else {
+					// Capture failed Consent create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to create Consent.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'consent')");
+					issues.add(issue);
+
+					// If sourceReference then hard delete DocumentReference or QuestionnaireResponse
+					if (sourceReference != null && sourceId != null) {
+						resourceService.purge(sourceId);
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			// Log exception
+			e.printStackTrace();
+			// Capture exception to OperationOutcome.issue
+			issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.FATAL, IssueType.EXCEPTION, e.getMessage(), null, "$fileConsent");
+			issues.add(issue);
+		}
+		finally {
+			// Release resources for garbage collection
+			xmlP = null;
+			createResource = null;
+			resCon = null;
+			oResource = null;
+			fileContent = null;
+			baseUrl = null;
+			sourceReference = null;
+			sourceId = null;
+		}
+
+		rOutcome = new OperationOutcome();
+		rOutcome.setIssue(issues);
+
+//		// OPERATION NOT IMPLEMENTED DEFAULT RESPONSE - REMOVE WHEN IMPLEMENTATION IS COMPLETE
+//		String outcome = ServicesUtil.INSTANCE.getOperationOutcome(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.NOTSUPPORTED, "$fileConsent not implemented.", null, null, "application/fhir+xml");
+//
+//		XmlParser xmlParser = new XmlParser();
+//
+//		rOutcome = (OperationOutcome) xmlParser.parse(outcome);
+
+		log.info("[END] FASTConsentFileConsent.performFileConsent()");
+
+		return rOutcome;
+	}
+
+}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentRecordDisclosure.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentRecordDisclosure.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * WildFHIR - wildfhir-model
+ * %%
+ * Copyright (C) 2024 AEGIS.net, Inc.
+ * All rights reserved.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *  - Neither the name of AEGIS nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package net.aegis.fhir.operation;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriInfo;
+
+import org.hl7.fhir.r4.formats.XmlParser;
+import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+
+import net.aegis.fhir.service.BatchService;
+import net.aegis.fhir.service.CodeService;
+import net.aegis.fhir.service.ConformanceService;
+import net.aegis.fhir.service.ResourceService;
+import net.aegis.fhir.service.ResourcemetadataService;
+import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
+import net.aegis.fhir.service.util.ServicesUtil;
+
+/**
+ * FAST Consent RI - $recordDisclosure operation
+ * 
+ * @author richard.ettema
+ *
+ */
+public class FASTConsentRecordDisclosure extends ResourceOperationProxy {
+
+	private Logger log = Logger.getLogger("FASTConsentRecordDisclosure");
+
+	private ResourceService resourceService;
+
+	/* (non-Javadoc)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 */
+	@Override
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+
+		log.fine("[START] FASTConsentRecordDisclosure.executeOperation()");
+
+        this.resourceService = resourceService;
+
+		Parameters out = new Parameters();
+
+		try {
+			/*
+			 * If inputParameters is null, throw exception
+			 */
+			if (inputParameters == null) {
+				throw new Exception("$recordDisclosure failed. The input parameters contents were empty or null.");
+			}
+
+			/*
+			 * Extract the individual expected parameters
+			 * - disclosure - FASTConsentAuditEvent resource (required)
+			 */
+			AuditEvent paramAuditEvent = null;
+
+			if (inputParameters != null && inputParameters.hasParameter()) {
+
+				for (ParametersParameterComponent parameter : inputParameters.getParameter()) {
+
+					if (parameter.getName() != null && parameter.getName().equals("disclosure") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("AuditEvent")) {
+							paramAuditEvent = (AuditEvent) paramResource;
+						}
+					}
+				}
+			}
+
+			/*
+			 * If the 'disclosure' input parameter is null, throw exception
+			 */
+			if (paramAuditEvent == null) {
+				throw new Exception("$recordDisclosure failed. The 'disclosure' input parameter was not defined or its resource contents were empty or null.");
+			}
+
+			OperationOutcome rOutcome = performRecordDisclosure(paramAuditEvent);
+
+			if (rOutcome == null) {
+				/*
+				 * Returned OperationOutcome is null, throw exception (should not happen)
+				 */
+				throw new Exception("$recordDisclosure failed. The attempt to record the AuditEvent disclosure resource produced a null outcome. Please verify the contents of the input payload.");
+			}
+
+			out = new Parameters();
+
+			ParametersParameterComponent parameter = new ParametersParameterComponent();
+			parameter.setName("return");
+			parameter.setResource(rOutcome);
+
+			out.addParameter(parameter);
+		}
+		catch (Exception e) {
+			// Throw exceptions back
+			e.printStackTrace();
+			throw new Exception("$recordDisclosure failed! Exception thrown: " + e.getMessage());
+		}
+
+		return out;
+	}
+
+	private OperationOutcome performRecordDisclosure(AuditEvent auditEvent) throws Exception {
+		OperationOutcome rOutcome = null;
+
+		/*
+		 * Creation of resources will generate corresponding Provenance and AuditEvent resource instances.
+		 * The AuditEvent resource must be processed in this order.
+		 * 
+		 * - Return the OperationOutcome
+		 */
+
+
+		// OPERATION NOT IMPLEMENTED DEFAULT RESPONSE - REMOVE WHEN IMPLEMENTATION IS COMPLETE
+		String outcome = ServicesUtil.INSTANCE.getOperationOutcome(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.NOTSUPPORTED, "$recordDisclosure not implemented.", null, null, "application/fhir+xml");
+
+		XmlParser xmlParser = new XmlParser();
+
+		rOutcome = (OperationOutcome) xmlParser.parse(outcome);
+
+		return rOutcome;
+	}
+
+}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentRevokeConsent.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentRevokeConsent.java
@@ -1,0 +1,192 @@
+/*
+ * #%L
+ * WildFHIR - wildfhir-model
+ * %%
+ * Copyright (C) 2024 AEGIS.net, Inc.
+ * All rights reserved.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *  - Neither the name of AEGIS nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package net.aegis.fhir.operation;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriInfo;
+
+import org.hl7.fhir.r4.formats.XmlParser;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+
+import net.aegis.fhir.service.BatchService;
+import net.aegis.fhir.service.CodeService;
+import net.aegis.fhir.service.ConformanceService;
+import net.aegis.fhir.service.ResourceService;
+import net.aegis.fhir.service.ResourcemetadataService;
+import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
+import net.aegis.fhir.service.util.ServicesUtil;
+
+/**
+ * FAST Consent RI - $fileConsent operation
+ * 
+ * @author richard.ettema
+ *
+ */
+public class FASTConsentRevokeConsent extends ResourceOperationProxy {
+
+	private Logger log = Logger.getLogger("FASTConsentRevokeConsent");
+
+	private ResourceService resourceService;
+
+	/* (non-Javadoc)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 */
+	@Override
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+
+		log.fine("[START] FASTConsentRevokeConsent.executeOperation()");
+
+        this.resourceService = resourceService;
+
+		Parameters out = new Parameters();
+
+		try {
+			/*
+			 * If inputParameters is null, throw exception
+			 */
+			if (inputParameters == null) {
+				throw new Exception("revokeConsent failed. The input parameters contents were empty or null.");
+			}
+
+			/*
+			 * Extract the individual expected parameters
+			 * - consent - FASTConsent Reference (required)
+			 * - patient - US Core Patient Reference (required)
+			 * - document - FASTDocumentReference or FASTQuestionnaireResponse resource (optional)
+			 */
+			Reference paramConsent = null;
+			Reference paramPatient = null;
+			DocumentReference paramDocumentReference = null;
+			QuestionnaireResponse paramQuestionnaireResponse = null;
+
+			if (inputParameters != null && inputParameters.hasParameter()) {
+
+				for (ParametersParameterComponent parameter : inputParameters.getParameter()) {
+
+					if (parameter.getName() != null && parameter.getName().equals("consent") &&
+							parameter.hasValue() && parameter.getValue() instanceof Reference) {
+
+						paramConsent = (Reference) parameter.getValue();
+					}
+
+					if (parameter.getName() != null && parameter.getName().equals("patient") &&
+							parameter.hasValue() && parameter.getValue() instanceof Reference) {
+
+						paramPatient = (Reference) parameter.getValue();
+					}
+
+					if (parameter.getName() != null && parameter.getName().equals("document") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("DocumentReference")) {
+							paramDocumentReference = (DocumentReference) paramResource;
+						}
+						else if (paramResource != null && paramResource.fhirType().equals("QuestionnaireResponse")) {
+							paramQuestionnaireResponse = (QuestionnaireResponse) paramResource;
+						}
+					}
+				}
+			}
+
+			/*
+			 * If the 'consent' or 'patient' input parameters are null, throw exception
+			 */
+			if (paramConsent == null || paramPatient == null) {
+				StringBuffer msg = new StringBuffer("$revokeConsent failed.");
+				if (paramConsent == null) {
+					msg.append(" The 'consent' input parameter was not defined or its value contents were empty or null.");
+				}
+				if (paramPatient == null) {
+					msg.append(" The 'patient' input parameter was not defined or its value contents were empty or null.");
+				}
+				throw new Exception(msg.toString());
+			}
+
+			OperationOutcome rOutcome = performRevokeConsent(paramConsent, paramPatient, paramDocumentReference, paramQuestionnaireResponse);
+
+			if (rOutcome == null) {
+				/*
+				 * Returned OperationOutcome is null, throw exception (should not happen)
+				 */
+				throw new Exception("$revokeConsent failed. The attempt to file the Consent and/or supporting document resources produced a null outcome. Please verify the contents of the input payload.");
+			}
+
+			out = new Parameters();
+
+			ParametersParameterComponent parameter = new ParametersParameterComponent();
+			parameter.setName("return");
+			parameter.setResource(rOutcome);
+
+			out.addParameter(parameter);
+		}
+		catch (Exception e) {
+			// Throw exceptions back
+			e.printStackTrace();
+			throw new Exception("$revokeConsent failed! Exception thrown: " + e.getMessage());
+		}
+
+		return out;
+	}
+
+	private OperationOutcome performRevokeConsent(Reference consent, Reference patient, DocumentReference documentReference, QuestionnaireResponse questionnaireResponse) throws Exception {
+		OperationOutcome rOutcome = null;
+
+		/*
+		 * Update of resources will generate corresponding Provenance and AuditEvent resource instances.
+		 * The Consent, DocumentReference and/or QuestionnaireResponse resource must be processed in this order.
+		 * - Return the OperationOutcome
+		 */
+
+
+		// OPERATION NOT IMPLEMENTED DEFAULT RESPONSE - REMOVE WHEN IMPLEMENTATION IS COMPLETE
+		String outcome = ServicesUtil.INSTANCE.getOperationOutcome(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.NOTSUPPORTED, "$revokeConsent not implemented.", null, null, "application/fhir+xml");
+
+		XmlParser xmlParser = new XmlParser();
+
+		rOutcome = (OperationOutcome) xmlParser.parse(outcome);
+
+		return rOutcome;
+	}
+
+}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentUpdateConsent.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/FASTConsentUpdateConsent.java
@@ -1,0 +1,480 @@
+/*
+ * #%L
+ * WildFHIR - wildfhir-model
+ * %%
+ * Copyright (C) 2024 AEGIS.net, Inc.
+ * All rights reserved.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *  - Neither the name of AEGIS nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package net.aegis.fhir.operation;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.Status;
+
+import org.hl7.fhir.r4.formats.XmlParser;
+import org.hl7.fhir.r4.formats.IParser.OutputStyle;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
+
+import net.aegis.fhir.model.ResourceContainer;
+import net.aegis.fhir.service.BatchService;
+import net.aegis.fhir.service.CodeService;
+import net.aegis.fhir.service.ConformanceService;
+import net.aegis.fhir.service.ResourceService;
+import net.aegis.fhir.service.ResourcemetadataService;
+import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventActionEnum;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceActivityTypeEnum;
+import net.aegis.fhir.service.provenance.ProvenanceService;
+import net.aegis.fhir.service.util.ServicesUtil;
+
+/**
+ * FAST Consent RI - $fileConsent operation
+ * 
+ * @author richard.ettema
+ *
+ */
+public class FASTConsentUpdateConsent extends ResourceOperationProxy {
+
+	private Logger log = Logger.getLogger("FASTConsentUpdateConsent");
+
+	private AuditEventService auditEventService;
+	private CodeService codeService;
+	private ProvenanceService provenanceService;
+	private ResourceService resourceService;
+	private XmlParser xmlP;
+
+	/* (non-Javadoc)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 */
+	@Override
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+
+		log.info("[START] FASTConsentUpdateConsent.executeOperation()");
+
+		this.auditEventService = auditEventService;
+		this.codeService = codeService;
+		this.provenanceService = provenanceService;
+        this.resourceService = resourceService;
+
+		Parameters out = new Parameters();
+
+		try {
+			/*
+			 * If inputParameters is null, throw exception
+			 */
+			if (inputParameters == null) {
+				throw new Exception("$updateConsent failed. The input parameters contents were empty or null.");
+			}
+
+			/*
+			 * Extract the individual expected parameters
+			 * - consent - FASTConsent resource (required)
+			 * - document - FASTDocumentReference or FASTQuestionnaireResponse resource (optional)
+			 */
+			boolean existingConsent = false;
+			Consent paramConsent = null;
+			DocumentReference paramDocumentReference = null;
+			QuestionnaireResponse paramQuestionnaireResponse = null;
+
+			if (inputParameters != null && inputParameters.hasParameter()) {
+
+				for (ParametersParameterComponent parameter : inputParameters.getParameter()) {
+
+					if (parameter.getName() != null && parameter.getName().equals("consent") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("Consent")) {
+							paramConsent = (Consent) paramResource;
+						}
+					}
+
+					if (parameter.getName() != null && parameter.getName().equals("document") && parameter.hasResource()) {
+
+						Resource paramResource = parameter.getResource();
+						if (paramResource != null && paramResource.fhirType().equals("DocumentReference")) {
+							paramDocumentReference = (DocumentReference) paramResource;
+						}
+						else if (paramResource != null && paramResource.fhirType().equals("QuestionnaireResponse")) {
+							paramQuestionnaireResponse = (QuestionnaireResponse) paramResource;
+						}
+					}
+				}
+			}
+
+			/*
+			 * If the 'consent' input parameter is null, throw exception
+			 */
+			if (paramConsent == null) {
+				throw new Exception("$updateConsent failed. The 'consent' input parameter was not defined or its resource contents were empty or null.");
+			}
+			else {
+				// Attempt to get(read/search) existing Consent; if not found, throw exception
+				if (paramConsent.hasId()) {
+					ResourceContainer readExisting = resourceService.read("Consent", paramConsent.getId(), null);
+					if (readExisting.getResponseStatus().equals(Response.Status.OK)) {
+						log.info("(read) Consent/" + paramConsent.getId() + " found.");
+						existingConsent = true;
+					}
+				}
+
+				if (existingConsent == false) {
+					// Read didn't work; try searching based on identifier, patient and/or organization
+
+					// Define query parameters and populate with search parameter values if defined
+					StringBuffer param = null;
+					MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+					if (paramConsent.hasIdentifier()) {
+						CommaSeparatedStringBuilder identifierParam = new CommaSeparatedStringBuilder();
+						for (Identifier identifier : paramConsent.getIdentifier()) {
+							param = new StringBuffer();
+							if (identifier.hasSystem()) {
+								param.append(identifier.getSystem()).append("|");
+							}
+							if (identifier.hasValue()) {
+								param.append(identifier.getValue());
+							}
+							if (param.length() > 1) {
+								identifierParam.append(param.toString());
+							}
+						}
+						if (identifierParam.length() > 1) {
+							queryParams.add("identifier", identifierParam.toString());
+						}
+					}
+					if (paramConsent.hasPatient()) {
+						if (paramConsent.getPatient().hasReference()) {
+							queryParams.add("patient", paramConsent.getPatient().getReference());
+						}
+						if (paramConsent.getPatient().hasIdentifier()) {
+							param = new StringBuffer();
+							if (paramConsent.getPatient().getIdentifier().hasSystem()) {
+								param.append(paramConsent.getPatient().getIdentifier().getSystem()).append("|");
+							}
+							if (paramConsent.getPatient().getIdentifier().hasValue()) {
+								param.append(paramConsent.getPatient().getIdentifier().getValue());
+							}
+							if (param.length() > 1) {
+								queryParams.add("patient:identifier", param.toString());
+							}
+						}
+					}
+					if (paramConsent.hasOrganization()) {
+						CommaSeparatedStringBuilder orgRefParam = new CommaSeparatedStringBuilder();
+						CommaSeparatedStringBuilder orgIdParam = new CommaSeparatedStringBuilder();
+						for (Reference orgRef : paramConsent.getOrganization()) {
+							if (orgRef.hasReference()) {
+								orgRefParam.append(orgRef.getReference());
+							}
+							if (orgRef.hasIdentifier()) {
+								param = new StringBuffer();
+								if (orgRef.getIdentifier().hasSystem()) {
+									param.append(orgRef.getIdentifier().getSystem()).append("|");
+								}
+								if (orgRef.getIdentifier().hasValue()) {
+									param.append(orgRef.getIdentifier().getValue());
+								}
+								if (param.length() > 1) {
+									orgIdParam.append(param.toString());
+								}
+							}
+						}
+						if (orgRefParam.length() > 1) {
+							queryParams.add("organization", orgRefParam.toString());
+						}
+						if (orgIdParam.length() > 1) {
+							queryParams.add("organization:identifier", orgIdParam.toString());
+						}
+					}
+
+					if (!queryParams.isEmpty()) {
+						List<String[]> validParams = new ArrayList<String[]>();
+						List<String[]> invalidParams = new ArrayList<String[]>();
+
+						List<net.aegis.fhir.model.Resource> resources = resourceService.searchQuery(queryParams, null, null, "Consent", false, null, null, null, validParams, invalidParams);
+
+						// Log any invalidParams
+						if (!invalidParams.isEmpty()) {
+							for (String[] invalidParam : invalidParams) {
+								if (invalidParam[0].equals("ERROR")) {
+									log.severe("Invalid search parameter '" + invalidParam[0] + "' found in search criteria." + (invalidParam.length > 1 && invalidParam[1] != null ? " " + invalidParam[1] : ""));
+								}
+								else {
+									log.warning("Invalid search parameter '" + invalidParam[0] + "' found in search criteria." + (invalidParam.length > 1 && invalidParam[1] != null ? " " + invalidParam[1] : ""));
+								}
+							}
+						}
+
+						if (resources != null && resources.size() == 1) {
+							// Exact match found; set paramConsent Resource.id
+							paramConsent.setId(resources.get(0).getResourceId());
+							log.info("(search) Consent/" + paramConsent.getId() + " found.");
+							existingConsent = true;
+						}
+					}
+				}
+
+				if (existingConsent == false) {
+					throw new Exception("$updateConsent failed. Cannot find the existing Consent resource based on the 'consent' input parameter.");
+				}
+			}
+
+			OperationOutcome rOutcome = performUpdateConsent(context, headers, paramConsent, paramDocumentReference, paramQuestionnaireResponse);
+
+			if (rOutcome == null) {
+				/*
+				 * Returned OperationOutcome is null, throw exception (should not happen)
+				 */
+				throw new Exception("$updateConsent failed. The attempt to file the Consent and/or supporting document resources produced a null outcome. Please verify the contents of the input payload.");
+			}
+
+			out = new Parameters();
+
+			ParametersParameterComponent parameter = new ParametersParameterComponent();
+			parameter.setName("return");
+			parameter.setResource(rOutcome);
+
+			out.addParameter(parameter);
+		}
+		catch (Exception e) {
+			// Throw exceptions back
+			e.printStackTrace();
+			throw new Exception("$updateConsent failed! Exception thrown: " + e.getMessage());
+		}
+
+		log.info("[END] FASTConsentUpdateConsent.executeOperation()");
+
+		return out;
+	}
+
+	private OperationOutcome performUpdateConsent(UriInfo context, HttpHeaders headers, Consent consent, DocumentReference documentReference, QuestionnaireResponse questionnaireResponse) throws Exception {
+
+		log.info("[START] FASTConsentUpdateConsent.performUpdateConsent()");
+
+		OperationOutcome rOutcome = null;
+		List<OperationOutcomeIssueComponent> issues = new ArrayList<OperationOutcomeIssueComponent>();
+		OperationOutcomeIssueComponent issue = null;
+
+		boolean ok = true;
+		xmlP = new XmlParser();
+		xmlP.setOutputStyle(OutputStyle.PRETTY);
+		net.aegis.fhir.model.Resource createUpdateResource = null;
+		ResourceContainer resCon = null;
+		ByteArrayOutputStream oResource = null;
+		byte fileContent[] = null;
+		String baseUrl = null;
+		Reference sourceReference = null;
+		Integer sourceId = null;
+
+		try {
+			// Get server base url from code table configuration
+			baseUrl = codeService.getCodeValue("baseUrl");
+
+			// Create DocumentReference if present
+			if (documentReference != null) {
+				createUpdateResource = new net.aegis.fhir.model.Resource();
+
+				// Remove existing Resource.id
+				documentReference.setIdElement(null);
+
+				// Convert documentReference to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, documentReference, true);
+				fileContent = oResource.toByteArray();
+
+				createUpdateResource.setResourceType("DocumentReference");
+				createUpdateResource.setResourceContents(fileContent);
+
+				resCon = resourceService.create(createUpdateResource, null, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					sourceReference = new Reference();
+					sourceReference.setReference("DocumentReference/" + resCon.getResource().getResourceId());
+					if (documentReference.hasIdentifier()) {
+						sourceReference.setIdentifier(documentReference.getIdentifierFirstRep());
+					}
+					// Save internal resource primary key if needed for hard delete
+					sourceId = resCon.getResource().getId();
+					// Capture successful DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							sourceReference.getReference() + " successfully created.", null, "Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = true;
+				}
+				else {
+					// Capture failed DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to create consent source DocumentReference.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = false;
+				}
+			}
+			// Create QuestionnaireResponse if present
+			else if (questionnaireResponse != null) {
+				createUpdateResource = new net.aegis.fhir.model.Resource();
+
+				// Remove existing Resource.id
+				questionnaireResponse.setIdElement(null);
+
+				// Convert questionnaireResponse to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, questionnaireResponse, true);
+				fileContent = oResource.toByteArray();
+
+				createUpdateResource.setResourceType("QuestionnaireResponse");
+				createUpdateResource.setResourceContents(fileContent);
+
+				resCon = resourceService.create(createUpdateResource, null, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					sourceReference = new Reference();
+					sourceReference.setReference("QuestionnaireResponse/" + resCon.getResource().getResourceId());
+					if (questionnaireResponse.hasIdentifier()) {
+						sourceReference.setIdentifier(questionnaireResponse.getIdentifier());
+					}
+					// Save internal resource primary key if needed for hard delete
+					sourceId = resCon.getResource().getId();
+					// Capture successful QuestionnaireResponse create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							sourceReference.getReference() + " successfully created.", null, "Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = true;
+				}
+				else {
+					// Capture failed QuestionnaireResponse create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to create consent source QuestionnaireResponse.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'document')");
+					issues.add(issue);
+					ok = false;
+				}
+			}
+
+			if (ok == true) {
+				// Create Consent
+				createUpdateResource = new net.aegis.fhir.model.Resource();
+
+				// Set Consent.source if needed
+				if (sourceReference != null) {
+					consent.setSource(sourceReference);
+				}
+
+				// Convert consent to XML for WildFHIR resource create
+				oResource = new ByteArrayOutputStream();
+				xmlP.compose(oResource, consent, true);
+				fileContent = oResource.toByteArray();
+
+				createUpdateResource.setResourceType("Consent");
+				createUpdateResource.setResourceContents(fileContent);
+
+				resCon = resourceService.update(consent.getId(), createUpdateResource, baseUrl);
+
+				if (resCon.getResponseStatus().equals(Status.OK)) {
+					// Create AuditEvent
+					auditEventService.createAuditEvent(context, headers, null, "Consent", true, resCon.getResource().getResourceId(), AuditEventActionEnum.UPDATE.getCode());
+					// Create Provenance
+					provenanceService.createProvenance(context, headers, null, "Consent", "Consent/" + resCon.getResource().getResourceId(), null, ProvenanceActivityTypeEnum.UPDATE.getCode());
+
+					// Capture successful DocumentReference create to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.INFORMATION, IssueType.PROCESSING,
+							"Consent/" + resCon.getResource().getResourceId() + " successfully updated.", null, "Parameters.parameter.where(name = 'consent')");
+					issues.add(issue);
+				}
+				else {
+					// Capture failed Consent update to OperationOutcome.issue
+					issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.ERROR, IssueType.PROCESSING,
+							"$fileConsent failed! Error attempting to update Consent.",
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""),
+							"Parameters.parameter.where(name = 'consent')");
+					issues.add(issue);
+
+					// If sourceReference then hard delete DocumentReference or QuestionnaireResponse
+					if (sourceReference != null && sourceId != null) {
+						resourceService.purge(sourceId);
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			// Log exception
+			e.printStackTrace();
+			// Capture exception to OperationOutcome.issue
+			issue = ServicesUtil.INSTANCE.getOperationOutcomeIssueComponent(IssueSeverity.FATAL, IssueType.EXCEPTION, e.getMessage(), null, "$fileConsent");
+			issues.add(issue);
+		}
+		finally {
+			// Release resources for garbage collection
+			xmlP = null;
+			createUpdateResource = null;
+			resCon = null;
+			oResource = null;
+			fileContent = null;
+			baseUrl = null;
+			sourceReference = null;
+			sourceId = null;
+		}
+
+		rOutcome = new OperationOutcome();
+		rOutcome.setIssue(issues);
+
+//		// OPERATION NOT IMPLEMENTED DEFAULT RESPONSE - REMOVE WHEN IMPLEMENTATION IS COMPLETE
+//		String outcome = ServicesUtil.INSTANCE.getOperationOutcome(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.NOTSUPPORTED, "$updateConsent not implemented.", null, null, "application/fhir+xml");
+//
+//		XmlParser xmlParser = new XmlParser();
+//
+//		rOutcome = (OperationOutcome) xmlParser.parse(outcome);
+
+		log.info("[END] FASTConsentUpdateConsent.performUpdateConsent()");
+
+		return rOutcome;
+	}
+
+}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/GlobalProcessMessage.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/GlobalProcessMessage.java
@@ -58,6 +58,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 
 /**
@@ -69,10 +71,10 @@ public class GlobalProcessMessage extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("GlobalProcessMessage");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
         log.fine("[START] GlobalProcessMessage.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/GlobalVersions.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/GlobalVersions.java
@@ -48,6 +48,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 
 /**
  * @author richard.ettema
@@ -60,10 +62,10 @@ public class GlobalVersions extends ResourceOperationProxy {
 	private CodeService codeService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
         log.fine("[START] GlobalVersions.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ObservationLastNOperation.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ObservationLastNOperation.java
@@ -80,6 +80,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.SummaryUtil;
 import net.aegis.fhir.service.util.UTCDateUtil;
@@ -94,10 +96,10 @@ public class ObservationLastNOperation extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("ObservationLastNOperation");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ObservationLastNOperation.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientEverything.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientEverything.java
@@ -33,6 +33,7 @@
 package net.aegis.fhir.operation;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,9 +58,11 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.linked.LinkedResourceProxy;
 import net.aegis.fhir.service.linked.LinkedResourceProxyObjectFactory;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.UUIDUtil;
 
@@ -86,10 +89,10 @@ public class PatientEverything extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("PatientEverything");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] PatientEverything.executeOperation()");
 
@@ -376,7 +379,10 @@ public class PatientEverything extends ResourceOperationProxy {
 					}
 				}
 
-				resources = resourceService.searchQuery(queryParams, null, null, lkvb.getKey(), false, null, null, null, null, null);
+				List<String[]> validParams = new ArrayList<String[]>();
+				List<String[]> invalidParams = new ArrayList<String[]>();
+
+				resources = resourceService.searchQuery(queryParams, null, null, lkvb.getKey(), false, null, null, null, validParams, invalidParams);
 
 				if (resources != null && resources.size() > 0) {
 					/*

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientMatch.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientMatch.java
@@ -63,6 +63,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.UTCDateUtil;
 
@@ -77,10 +79,10 @@ public class PatientMatch extends ResourceOperationProxy {
 	private ResourceService resourceService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
         log.fine("[START] PatientMatch.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientPurge.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/PatientPurge.java
@@ -32,6 +32,7 @@
  */
 package net.aegis.fhir.operation;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Map.Entry;
@@ -53,7 +54,9 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 
 import org.hl7.fhir.r4.model.DateType;
@@ -70,10 +73,10 @@ public class PatientPurge extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("PatientPurge");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] PatientPurge.executeOperation()");
 
@@ -251,7 +254,10 @@ public class PatientPurge extends ResourceOperationProxy {
 				}
 			}
 
-			resources = resourceService.searchQuery(queryParams, null, null, lkvb.getKey(), false, null, null, null, null, null);
+			List<String[]> validParams = new ArrayList<String[]>();
+			List<String[]> invalidParams = new ArrayList<String[]>();
+
+			resources = resourceService.searchQuery(queryParams, null, null, lkvb.getKey(), false, null, null, null, validParams, invalidParams);
 
 			if (resources != null && resources.size() > 0) {
 				/*

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceConvertFormat.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceConvertFormat.java
@@ -46,6 +46,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 
 /**
  * @author richard.ettema
@@ -56,10 +58,10 @@ public class ResourceConvertFormat extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("ResourceConvertFormat");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceConvertFormat.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceLoadExamples.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceLoadExamples.java
@@ -53,6 +53,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.UUIDUtil;
 
 import org.apache.commons.io.FileUtils;
@@ -86,10 +88,10 @@ public class ResourceLoadExamples extends ResourceOperationProxy {
 	private JsonParser jsonP;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceLoadExamples.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMeta.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMeta.java
@@ -49,7 +49,9 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.util.UUIDUtil;
 
@@ -73,10 +75,10 @@ public class ResourceMeta extends ResourceOperationProxy {
 	private ResourcemetadataService resourcemetadataService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceMeta.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMetaAdd.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMetaAdd.java
@@ -49,6 +49,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.UUIDUtil;
 
 import org.hl7.fhir.r4.formats.XmlParser;
@@ -72,10 +74,10 @@ public class ResourceMetaAdd extends ResourceOperationProxy {
 	private ResourceService resourceService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceMetaAdd.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMetaDelete.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceMetaDelete.java
@@ -49,6 +49,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.UUIDUtil;
 
 import org.hl7.fhir.r4.formats.XmlParser;
@@ -72,10 +74,10 @@ public class ResourceMetaDelete extends ResourceOperationProxy {
 	private ResourceService resourceService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceMetaDelete.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceOperationProxy.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceOperationProxy.java
@@ -41,6 +41,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Resource;
@@ -61,6 +63,8 @@ public abstract class ResourceOperationProxy {
 	 * @param batchService
 	 * @param transactionService
 	 * @param codeService
+	 * @param auditEventService
+	 * @param provenanceService
 	 * @param conformanceService
 	 * @param softwareVersion
 	 * @param resourceType
@@ -74,6 +78,6 @@ public abstract class ResourceOperationProxy {
 	 * @return <code>Parameters</code>
 	 * @throws Exception
 	 */
-	public abstract Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception;
+	public abstract Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception;
 
 }

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceOperationProxyObjectFactory.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceOperationProxyObjectFactory.java
@@ -87,6 +87,20 @@ public class ResourceOperationProxyObjectFactory {
 				proxy = new CompositionDocument();
 			}
 		}
+		else if (resourceType.equals(ResourceType.Consent.name())) {
+			if (operationName.equals("fileConsent")) {
+				proxy = new FASTConsentFileConsent();
+			}
+			else if (operationName.equals("recordDisclosure")) {
+				proxy = new FASTConsentRecordDisclosure();
+			}
+			else if (operationName.equals("revokeConsent")) {
+				proxy = new FASTConsentRevokeConsent();
+			}
+			else if (operationName.equals("updateConsent")) {
+				proxy = new FASTConsentUpdateConsent();
+			}
+		}
 		else if (resourceType.equals(ResourceType.Observation.name())) {
 			if (operationName.equals("lastn")) {
 				proxy = new ObservationLastNOperation();

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourcePurgeAll.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourcePurgeAll.java
@@ -48,7 +48,9 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 
 /**
@@ -64,10 +66,10 @@ public class ResourcePurgeAll extends ResourceOperationProxy {
 	private ResourceService resourceService;
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourcePurgeAll.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceValidation.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/operation/ResourceValidation.java
@@ -50,6 +50,8 @@ import net.aegis.fhir.service.ConformanceService;
 import net.aegis.fhir.service.ResourceService;
 import net.aegis.fhir.service.ResourcemetadataService;
 import net.aegis.fhir.service.TransactionService;
+import net.aegis.fhir.service.audit.AuditEventService;
+import net.aegis.fhir.service.provenance.ProvenanceService;
 import net.aegis.fhir.service.util.ServicesUtil;
 import net.aegis.fhir.service.validation.FHIRValidatorClient;
 
@@ -74,10 +76,10 @@ public class ResourceValidation extends ResourceOperationProxy {
 	private Logger log = Logger.getLogger("ResourceValidation");
 
 	/* (non-Javadoc)
-	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
+	 * @see net.aegis.fhir.operation.ResourceOperationProxy#executeOperation(javax.ws.rs.core.UriInfo, javax.ws.rs.core.HttpHeaders, net.aegis.fhir.service.ResourceService, net.aegis.fhir.service.ResourcemetadataService, net.aegis.fhir.service.BatchService, net.aegis.fhir.service.TransactionService, net.aegis.fhir.service.CodeService, net.aegis.fhir.service.audit.AuditEventService, net.aegis.fhir.service.provenance.ProvenanceService, net.aegis.fhir.service.ConformanceService, java.lang.String, java.lang.String, java.lang.String, org.hl7.fhir.r4.model.Parameters, org.hl7.fhir.r4.model.Resource, java.lang.String, java.lang.String, boolean, java.lang.StringBuffer)
 	 */
 	@Override
-	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
+	public Parameters executeOperation(UriInfo context, HttpHeaders headers, ResourceService resourceService, ResourcemetadataService resourcemetadataService, BatchService batchService, TransactionService transactionService, CodeService codeService, AuditEventService auditEventService, ProvenanceService provenanceService, ConformanceService conformanceService, String softwareVersion, String resourceType, String resourceId, Parameters inputParameters, org.hl7.fhir.r4.model.Resource inputResource, String inputString, String contentType, boolean isPost, StringBuffer returnedDirective) throws Exception {
 
 		log.fine("[START] ResourceValidation.executeOperation()");
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/RESTResourceOps.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/RESTResourceOps.java
@@ -77,7 +77,6 @@ import com.google.gson.JsonSyntaxException;
 import net.aegis.fhir.model.Constants;
 import net.aegis.fhir.model.ResourceContainer;
 import net.aegis.fhir.model.ResourceType;
-import net.aegis.fhir.service.audit.AuditEventActionEnum;
 import net.aegis.fhir.service.audit.AuditEventService;
 import net.aegis.fhir.service.narrative.FHIRNarrativeGeneratorClient;
 import net.aegis.fhir.service.provenance.ProvenanceService;
@@ -420,7 +419,7 @@ public class RESTResourceOps {
      * @param resourceId
      * @return <code>Response</code>
      */
-    public Response create(UriInfo context, HttpHeaders headers, MultivaluedMap<String,String> requestHeaderParams, String payload, String resourceType, String resourceId) {
+    public Response create(UriInfo context, HttpHeaders headers, MultivaluedMap<String,String> requestHeaderParams, String payload, String resourceType, String resourceId) throws Exception {
 
         log.fine("[START] RESTResourceOps.create()");
 
@@ -721,9 +720,6 @@ public class RESTResourceOps {
 
         response = builder.build();
 
-		// Audit the create operation
-		auditEventService.createAuditEvent(context, headers, payload, resourceType, response , null, AuditEventActionEnum.CREATE.getCode());
-
         return response;
 
     }
@@ -740,7 +736,7 @@ public class RESTResourceOps {
      * @param resourceType
      * @return <code>Response</code>
      */
-    public Response update(UriInfo context, HttpHeaders headers, MultivaluedMap<String,String> requestHeaderParams, MultivaluedMap<String,String> contextQueryParams, String id, String payload, String resourceType) {
+    public Response update(UriInfo context, HttpHeaders headers, MultivaluedMap<String,String> requestHeaderParams, MultivaluedMap<String,String> contextQueryParams, String id, String payload, String resourceType) throws Exception {
 
         log.fine("[START] RESTResourceOps.update()");
 
@@ -1168,9 +1164,6 @@ public class RESTResourceOps {
         }
 
         response = builder.build();
-
-		// Audit the update operation
-		auditEventService.createAuditEvent(context, headers, payload, resourceType, response, id, AuditEventActionEnum.UPDATE.getCode());
 
         return response;
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/ResourceService.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/ResourceService.java
@@ -3456,6 +3456,12 @@ public class ResourceService {
 								 */
 							}
 							else {
+								if (key.contains(":identifier")) {
+									// reference type modifier; must treat value as token
+									isReferenceType = false;
+									isTokenType = true;
+								}
+
 								if (value != null & value.length() > 0) {
 									log.info("resourceType = '" + (resourceType == null ? "null" : resourceType) + "'; key = '" + key + "'; value = '" + value + "'");
 									// Initialize TimeZones

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventCreateResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventCreateResource.java
@@ -33,12 +33,14 @@
 package net.aegis.fhir.service.audit;
 
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Reference;
 
 /**
  * @author Venkat.Keesara
@@ -47,10 +49,43 @@ import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
 public class AuditEventCreateResource extends AuditEventResourceProxy {
 
 	@Override
-	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, Response response, String resourceId, String operation) throws Exception {
+	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
 
 		AuditEvent audit = new AuditEvent();
+
 		prepareBasicData(audit, context, headers, response);
+
+		// subType is FHIR create
+		Coding coding = new Coding();
+		coding.setSystem("http://hl7.org/fhir/restful-interaction");
+		coding.setCode("create");
+		audit.addSubtype(coding);
+
+		// entity based on resourceType and resourceId
+		AuditEventEntityComponent entity = new AuditEventEntityComponent();
+
+		Reference what = new Reference();
+		what.setReference(resourceType + "/" + resourceId);
+		entity.setWhat(what);
+
+		coding = new Coding();
+		coding.setSystem("http://hl7.org/fhir/resource-types");
+		coding.setCode(resourceType);
+		entity.setType(coding);
+
+		coding = new Coding();
+		coding.setSystem("http://terminology.hl7.org/CodeSystem/object-role");
+		coding.setCode("4");
+		entity.setRole(coding);
+
+		coding = new Coding();
+		coding.setSystem("http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle");
+		coding.setCode("1");
+		coding.setDisplay("Origination / Creation");
+		entity.setLifecycle(coding);
+
+		audit.addEntity(entity);
+
 		return audit;
 	}
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventDeleteResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventDeleteResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -35,18 +35,18 @@ package net.aegis.fhir.service.audit;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class AuditEventUpdateResource extends AuditEventResourceProxy {
+public class AuditEventDeleteResource extends AuditEventResourceProxy {
 
 	@Override
 	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
@@ -55,10 +55,10 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		prepareBasicData(audit, context, headers, response);
 
-		// subType is FHIR update
+		// subType is FHIR delete
 		Coding coding = new Coding();
 		coding.setSystem("http://hl7.org/fhir/restful-interaction");
-		coding.setCode("update");
+		coding.setCode("delete");
 		audit.addSubtype(coding);
 
 		// entity based on resourceType and resourceId
@@ -80,8 +80,8 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		coding = new Coding();
 		coding.setSystem("http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle");
-		coding.setCode("3");
-		coding.setDisplay("Amendment");
+		coding.setCode("14");
+		coding.setDisplay("Logical deletion");
 		entity.setLifecycle(coding);
 
 		audit.addEntity(entity);
@@ -91,7 +91,7 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 	@Override
 	public AuditEventAction setAction() {
-		return AuditEventAction.U;
+		return AuditEventAction.D;
 	}
 
 }

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventExecuteResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventExecuteResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -35,18 +35,18 @@ package net.aegis.fhir.service.audit;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class AuditEventUpdateResource extends AuditEventResourceProxy {
+public class AuditEventExecuteResource extends AuditEventResourceProxy {
 
 	@Override
 	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
@@ -55,10 +55,10 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		prepareBasicData(audit, context, headers, response);
 
-		// subType is FHIR update
+		// subType is FHIR operation
 		Coding coding = new Coding();
 		coding.setSystem("http://hl7.org/fhir/restful-interaction");
-		coding.setCode("update");
+		coding.setCode("operation");
 		audit.addSubtype(coding);
 
 		// entity based on resourceType and resourceId
@@ -80,8 +80,8 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		coding = new Coding();
 		coding.setSystem("http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle");
-		coding.setCode("3");
-		coding.setDisplay("Amendment");
+		coding.setCode("6");
+		coding.setDisplay("Access / Use");
 		entity.setLifecycle(coding);
 
 		audit.addEntity(entity);
@@ -91,7 +91,7 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 	@Override
 	public AuditEventAction setAction() {
-		return AuditEventAction.U;
+		return AuditEventAction.E;
 	}
 
 }

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventReadViewPrintResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventReadViewPrintResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -35,18 +35,18 @@ package net.aegis.fhir.service.audit;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventEntityComponent;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class AuditEventUpdateResource extends AuditEventResourceProxy {
+public class AuditEventReadViewPrintResource extends AuditEventResourceProxy {
 
 	@Override
 	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
@@ -55,10 +55,10 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		prepareBasicData(audit, context, headers, response);
 
-		// subType is FHIR update
+		// subType is FHIR read
 		Coding coding = new Coding();
 		coding.setSystem("http://hl7.org/fhir/restful-interaction");
-		coding.setCode("update");
+		coding.setCode("read");
 		audit.addSubtype(coding);
 
 		// entity based on resourceType and resourceId
@@ -80,8 +80,8 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 		coding = new Coding();
 		coding.setSystem("http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle");
-		coding.setCode("3");
-		coding.setDisplay("Amendment");
+		coding.setCode("6");
+		coding.setDisplay("Access / Use");
 		entity.setLifecycle(coding);
 
 		audit.addEntity(entity);
@@ -91,7 +91,7 @@ public class AuditEventUpdateResource extends AuditEventResourceProxy {
 
 	@Override
 	public AuditEventAction setAction() {
-		return AuditEventAction.U;
+		return AuditEventAction.R;
 	}
 
 }

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventResourceProxy.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventResourceProxy.java
@@ -66,38 +66,36 @@ import net.aegis.fhir.service.util.ServicesUtil;
  *
  */
 public abstract class AuditEventResourceProxy {
-	private Logger log = Logger.getLogger(getClass().getName());
-	public static String appId = AuditEventConstant.HEADER_APPLICATION_NAME;
-	public static String userId = AuditEventConstant.HEADER_USER_ID;
-	public static String userName = AuditEventConstant.HEADER_USER_NAME;
-	public static String site = AuditEventConstant.HEADER_SITE_NAME;
 
-	public abstract Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, Response response, String resourceId, String operation) throws Exception;
+	private Logger log = Logger.getLogger(getClass().getName());
+
+	public static String appId = "FASTConsentRI";
+	public static String userId = "consent-ri-system";
+	public static String userName = "FAST Consent RI System";
+	public static String site = "consent-ri-site";
+
+	public abstract Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception;
 
 	public abstract AuditEventAction setAction();
 
-	protected void prepareBasicData(AuditEvent audit, UriInfo context, HttpHeaders headers, Response response) throws Exception {
+	protected void prepareBasicData(AuditEvent audit, UriInfo context, HttpHeaders headers, boolean response) throws Exception {
 
 		try {
 			// audit.addChild("type"); // Not recommended as Oath is not implemented yet
 			audit.setType(getType(headers));
 
-			audit.addSubtype();
-			// No enum needed for SUB type . We can use this based on operation
-			/*
-			 * TypeRestfulInteraction.READ.getSystem(); TypeRestfulInteraction.READ.getDefinition();
-			 * TypeRestfulInteraction.READ.getDisplay(); TypeRestfulInteraction.READ.toCode();
-			 */
-			// audit.addChild("action");
+			// sub type set in implementation class
+
 			audit.setAction(setAction());
 
 			audit.setRecorded(new Date());
 			audit.setOutcome(getOutcome(response));
-			//audit.setOutcomeDesc(value);
+
 			audit.addChild("purposeOfEvent");
 			List<AuditEventAgentComponent> agentList = new ArrayList<>();
 			agentList.add(getAgent(headers));
 			audit.setAgent(agentList);
+
 			// context will have Source info ( who sent to us )
 			audit.setSource(getSourceElement(headers));
 
@@ -105,8 +103,8 @@ public abstract class AuditEventResourceProxy {
 			log.info("prepareBasicData");
 		}
 		catch (FHIRException e) {
-			log.severe(e.getMessage());
-			//e.printStackTrace();
+			e.printStackTrace();
+			throw e;
 		}
 
 	}
@@ -139,37 +137,26 @@ public abstract class AuditEventResourceProxy {
 		return action;
 	}
 
-	/*
-	 * protected AuditEventAction getAction(HttpHeaders headers) throws RuntimeException {
-	 *
-	 * AuditEventAction enumValue = AuditEventAction.C ; return enumValue ;
-	 *
-	 * }
-	 */
-
 	protected Enumeration<AuditEventOutcome> getOutcomeEnum(Response response) {
 		AuditEventOutcomeEnumFactory auditEventoutcomeEnumFactory = new AuditEventOutcomeEnumFactory();
 		Enumeration<AuditEventOutcome> outcome = new Enumeration<AuditEventOutcome>(auditEventoutcomeEnumFactory);
+		outcome.setValue(AuditEventOutcome._0);
 
 		if (response != null) {
 			int status = response.getStatus();
 
-			if (Response.Status.BAD_REQUEST.getStatusCode() != status) {
-
+			if (Response.Status.BAD_REQUEST.getStatusCode() == status) {
+				outcome.setValue(AuditEventOutcome._8);
 			}
 
 		}
 		return outcome;
 	}
 
-	protected AuditEventOutcome getOutcome(Response response) {
+	protected AuditEventOutcome getOutcome(boolean response) {
 		AuditEventOutcome enumValue = AuditEventOutcome._0;
-		if (response != null) {
-			int status = response.getStatus();
-
-			if (Response.Status.BAD_REQUEST.getStatusCode() != status) {
-				enumValue = AuditEventOutcome._12;
-			}
+		if (response == false) {
+			enumValue = AuditEventOutcome._8;
 		}
 		return enumValue;
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventResourceProxyObjectFactory.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventResourceProxyObjectFactory.java
@@ -52,8 +52,17 @@ public class AuditEventResourceProxyObjectFactory {
 			if (AuditEventActionEnum.CREATE.getCode() == operation) {
 				proxy = new AuditEventCreateResource();
 			}
+			if (AuditEventActionEnum.READ_VIEW_PRINT.getCode() == operation) {
+				proxy = new AuditEventReadViewPrintResource();
+			}
 			if (AuditEventActionEnum.UPDATE.getCode() == operation) {
 				proxy = new AuditEventUpdateResource();
+			}
+			if (AuditEventActionEnum.DELETE.getCode() == operation) {
+				proxy = new AuditEventDeleteResource();
+			}
+			if (AuditEventActionEnum.EXECUTE.getCode() == operation) {
+				proxy = new AuditEventExecuteResource();
 			}
 
 		}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventService.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventService.java
@@ -32,30 +32,20 @@
  */
 package net.aegis.fhir.service.audit;
 
-import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.transaction.UserTransaction;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-
-import org.hl7.fhir.r4.formats.IParser.OutputStyle;
-import org.hl7.fhir.r4.formats.XmlParser;
-import org.hl7.fhir.r4.model.Meta;
+import javax.ws.rs.core.Response.Status;
 
 import net.aegis.fhir.model.Resource;
+import net.aegis.fhir.model.ResourceContainer;
 import net.aegis.fhir.service.CodeService;
 import net.aegis.fhir.service.ResourceService;
-import net.aegis.fhir.service.util.UUIDUtil;
 
 /**
  * @author Venkat.Keesara
@@ -69,16 +59,9 @@ public class AuditEventService {
 
 	@Inject
 	CodeService codeService;
+
 	@Inject
 	ResourceService resourceService;
-
-	@PersistenceContext
-	private EntityManager em;
-
-	@javax.annotation.Resource
-	private UserTransaction userTransaction;
-	@Inject
-	private Event<net.aegis.fhir.model.Resource> resourceEventSrc;
 
 	/**
 	 * @param context
@@ -86,63 +69,43 @@ public class AuditEventService {
 	 * @param payload
 	 * @param resourceType
 	 * @param response
-	 * @param string
+	 * @param resourceId
+	 * @param operation
 	 * @throws Exception
 	 */
-	public void createAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, Response response, String resourceId, String operation) {
+	public void createAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
+
+		Resource resource = null;
+		ResourceContainer resCon = null;
+		String baseUrl = null;
 
 		try {
 			if (codeService.isSupported("auditEventServiceEnabled")) {
-				Resource resource = AuditEventServiceUtil.INSTANCE.generateAuditEvent(context, headers, payload, resourceType, response, resourceId, operation);
+				resource = AuditEventServiceUtil.INSTANCE.generateAuditEvent(context, headers, payload, resourceType, response, resourceId, operation);
 
-				String nextResourceIdString = UUIDUtil.getGUID();
-				int nextVersionId = 1;
-				Date updatedTime = new Date();
+				// Get server base url from code table configuration
+				baseUrl = codeService.getCodeValue("baseUrl");
 
-				// create a new wildfhir resource; version based on whether we came from an update or not
-				net.aegis.fhir.model.Resource newResource = new net.aegis.fhir.model.Resource();
-				newResource.setResourceId(nextResourceIdString);
-				newResource.setVersionId(Integer.valueOf(nextVersionId));
-				newResource.setResourceType(resource.getResourceType());
-				newResource.setStatus("valid");
-				newResource.setLastUser("system");
-				newResource.setLastUpdate(updatedTime);
+				resCon = resourceService.create(resource, null, baseUrl);
 
-				// Convert XML contents to Resource object and set id and meta
-				ByteArrayInputStream iResource = new ByteArrayInputStream(resource.getResourceContents());
-				XmlParser xmlP = new XmlParser();
-				xmlP.setOutputStyle(OutputStyle.PRETTY);
-				org.hl7.fhir.r4.model.Resource resourceObject = xmlP.parse(iResource);
-
-				resourceObject.setId(nextResourceIdString);
-
-				Meta resourceMeta = new Meta();
-				if (resourceObject.hasMeta()) {
-					resourceMeta = resourceObject.getMeta();
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					log.info("AuditEventService.createAuditEvent() - AuditEvent/" + resCon.getResource().getResourceId() + " successfully created.");
 				}
-				resourceMeta.setVersionId(Integer.toString(nextVersionId));
-				resourceMeta.setLastUpdated(updatedTime);
-				resourceObject.setMeta(resourceMeta);
-				byte[] resourceBytes = xmlP.composeBytes(resourceObject);
-
-				newResource.setResourceContents(resourceBytes);
-
-				/*
-				 * TRANSACTION BEGIN
-				 */
-				userTransaction.begin();
-				em.persist(newResource);
-				resourceEventSrc.fire(newResource);
-
-				/*
-				 * TRANSACTION COMMIT(END)
-				 */
-				userTransaction.commit();
+				else {
+					throw new Exception("Error attempting to create AuditEvent! " +
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""));
+				}
 			}
 		}
 		catch (Exception e) {
-			log.severe(e.getMessage());
-			// e.printStackTrace();
+			e.printStackTrace();
+			throw e;
+		}
+		finally {
+			// Release resources for garbage collection
+			resource = null;
+			resCon = null;
+			baseUrl = null;
 		}
 
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventServiceUtil.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/audit/AuditEventServiceUtil.java
@@ -35,7 +35,6 @@ package net.aegis.fhir.service.audit;
 import java.io.ByteArrayOutputStream;
 
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.hl7.fhir.r4.formats.IParser.OutputStyle;
@@ -54,7 +53,7 @@ public enum AuditEventServiceUtil {
 	private AuditEventServiceUtil() {
 	}
 
-	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, Response response, String resourceId, String operation) throws Exception {
+	public Resource generateAuditEvent(UriInfo context, HttpHeaders headers, String payload, String resourceType, boolean response, String resourceId, String operation) throws Exception {
 		net.aegis.fhir.model.Resource resourceDomain = new net.aegis.fhir.model.Resource();
 		AuditEventResourceProxyObjectFactory objectFactory = new AuditEventResourceProxyObjectFactory();
 		AuditEventResourceProxy proxy = objectFactory.getAuditEventResourceProxy(resourceType, operation);

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceActivityTypeEnum.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceActivityTypeEnum.java
@@ -39,45 +39,44 @@ package net.aegis.fhir.service.provenance;
 public enum ProvenanceActivityTypeEnum {
 
 	/**
-	 * Display: <b>Create</b><br/>
-	 * Code Value: <b>C</b>
+	 * Display: <b>create</b><br/>
+	 * Code Value: <b>CREATE</b>
 	 *
-	 * Create a new database object, such as Placing an Order.
+	 * Fundamental operation in an Information System (IS) that results only in the act of bringing an object into existence.
 	 */
-	CREATE("CREATE", "http://hl7.org/fhir/v3/DataOperation", "Create"),
+	CREATE("CREATE", "http://terminology.hl7.org/CodeSystem/v3-DataOperation", "create"),
 
 	/**
-	 * Display: <b>Read/View/Print</b><br/>
-	 * Code Value: <b>R</b>
+	 * Display: <b>delete</b><br/>
+	 * Code Value: <b>DELETE</b>
 	 *
-	 * Display or print data, such as a Doctor Census.
+	 * Fundamental operation in an Information System (IS) that results only in the removal of information about an object from memory or storage.
 	 */
-	OPERATE("OPERATE", "http://hl7.org/fhir/v3/DataOperation", "Read/View/Print"),
+	DELETE("DELETE", "http://terminology.hl7.org/CodeSystem/v3-DataOperation", "delete"),
 
 	/**
-	 * Display: <b>Update</b><br/>
-	 * Code Value: <b>U</b>
+	 * Display: <b>update</b><br/>
+	 * Code Value: <b>UPDATE</b>
 	 *
-	 * Update data, such as Revise Patient Information.
+	 * Fundamental operation in an Information System (IS) that results only in the revision or alteration of an object.
 	 */
-	UPDATE("UPDATE", "http://hl7.org/fhir/v3/DataOperation", "Update"),
+	UPDATE("UPDATE", "http://terminology.hl7.org/CodeSystem/v3-DataOperation", "revise"),
 
 	/**
-	 * Display: <b>Delete</b><br/>
-	 * Code Value: <b>D</b>
+	 * Display: <b>append</b><br/>
+	 * Code Value: <b>APPEND</b>
 	 *
-	 * Delete items, such as a doctor master file record.
+	 * Fundamental operation in an Information System (IS) that results only in the addition of information to an object already in existence.
 	 */
-	DELETE("DELETE", "http://hl7.org/fhir/v3/DataOperation", "Delete"),
+	APPEND("APPEND", "http://terminology.hl7.org/CodeSystem/v3-DataOperation", "append"),
 
 	/**
-	 * Display: <b>Execute</b><br/>
-	 * Code Value: <b>E</b>
+	 * Display: <b>nullify</b><br/>
+	 * Code Value: <b>NULLIFY</b>
 	 *
-	 * Perform a system or application function such as log-on, program execution or use of an object's method, or
-	 * perform a query/search operation.
+	 * Change the status of an object representing an Act to "nullified", i.e., treat as though it never existed.
 	 */
-	EXECUTE("EXECUTE", "http://hl7.org/fhir/v3/DataOperation", "Execute"),
+	NULLIFY("NULLIFY", "http://terminology.hl7.org/CodeSystem/v3-DataOperation", "nullify"),
 
 	;
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceAppendResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceAppendResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -41,10 +41,10 @@ import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class ProvenanceCreateResource extends ProvenanceResourceProxy {
+public class ProvenanceAppendResource extends ProvenanceResourceProxy {
 
 	@Override
 	public Resource generateProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception {
@@ -60,9 +60,9 @@ public class ProvenanceCreateResource extends ProvenanceResourceProxy {
 	public CodeableConcept getActivity() {
 		CodeableConcept activity = new CodeableConcept();
 		Coding activityCoding = new Coding();
-		activityCoding.setSystem(ProvenanceActivityTypeEnum.CREATE.getSystem());
-		activityCoding.setCode(ProvenanceActivityTypeEnum.CREATE.getCode());
-		activityCoding.setDisplay(ProvenanceActivityTypeEnum.CREATE.getDisplay());
+		activityCoding.setSystem(ProvenanceActivityTypeEnum.APPEND.getSystem());
+		activityCoding.setCode(ProvenanceActivityTypeEnum.APPEND.getCode());
+		activityCoding.setDisplay(ProvenanceActivityTypeEnum.APPEND.getDisplay());
 		activity.addCoding(activityCoding);
 		return activity;
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceDeleteResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceDeleteResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -41,10 +41,10 @@ import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class ProvenanceCreateResource extends ProvenanceResourceProxy {
+public class ProvenanceDeleteResource extends ProvenanceResourceProxy {
 
 	@Override
 	public Resource generateProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception {
@@ -60,9 +60,9 @@ public class ProvenanceCreateResource extends ProvenanceResourceProxy {
 	public CodeableConcept getActivity() {
 		CodeableConcept activity = new CodeableConcept();
 		Coding activityCoding = new Coding();
-		activityCoding.setSystem(ProvenanceActivityTypeEnum.CREATE.getSystem());
-		activityCoding.setCode(ProvenanceActivityTypeEnum.CREATE.getCode());
-		activityCoding.setDisplay(ProvenanceActivityTypeEnum.CREATE.getDisplay());
+		activityCoding.setSystem(ProvenanceActivityTypeEnum.DELETE.getSystem());
+		activityCoding.setCode(ProvenanceActivityTypeEnum.DELETE.getCode());
+		activityCoding.setDisplay(ProvenanceActivityTypeEnum.DELETE.getDisplay());
 		activity.addCoding(activityCoding);
 		return activity;
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceNullifyResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceNullifyResource.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * WildFHIR - wildfhir-service
+ * WildFHIR - wildfhir-model
  * %%
  * Copyright (C) 2024 AEGIS.net, Inc.
  * All rights reserved.
@@ -41,10 +41,10 @@ import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Resource;
 
 /**
- * @author Venkat.Keesara
+ * @author richard.ettema
  *
  */
-public class ProvenanceCreateResource extends ProvenanceResourceProxy {
+public class ProvenanceNullifyResource extends ProvenanceResourceProxy {
 
 	@Override
 	public Resource generateProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception {
@@ -60,9 +60,9 @@ public class ProvenanceCreateResource extends ProvenanceResourceProxy {
 	public CodeableConcept getActivity() {
 		CodeableConcept activity = new CodeableConcept();
 		Coding activityCoding = new Coding();
-		activityCoding.setSystem(ProvenanceActivityTypeEnum.CREATE.getSystem());
-		activityCoding.setCode(ProvenanceActivityTypeEnum.CREATE.getCode());
-		activityCoding.setDisplay(ProvenanceActivityTypeEnum.CREATE.getDisplay());
+		activityCoding.setSystem(ProvenanceActivityTypeEnum.NULLIFY.getSystem());
+		activityCoding.setCode(ProvenanceActivityTypeEnum.NULLIFY.getCode());
+		activityCoding.setDisplay(ProvenanceActivityTypeEnum.NULLIFY.getDisplay());
 		activity.addCoding(activityCoding);
 		return activity;
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceResourceProxy.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceResourceProxy.java
@@ -43,7 +43,8 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Provenance.ProvenanceAgentComponent;
 import org.hl7.fhir.r4.model.Provenance.ProvenanceEntityRole;
@@ -61,16 +62,17 @@ import net.aegis.fhir.service.util.UUIDUtil;
  *
  */
 public abstract class ProvenanceResourceProxy {
+
 	private Logger log = Logger.getLogger(getClass().getName());
 
-	public static String appId = AuditEventConstant.HEADER_APPLICATION_NAME;
-	public static String userId = AuditEventConstant.HEADER_USER_ID;
-	public static String userName = AuditEventConstant.HEADER_USER_NAME;
-	public static String site = AuditEventConstant.HEADER_SITE_NAME;
+	public static String appId = "FASTConsentRI";
+	public static String userId = "consent-ri-system";
+	public static String userName = "FAST Consent RI System";
+	public static String site = "consent-ri-site";
 
 	public abstract Resource generateProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception;
 
-	public abstract AuditEventAction setAction();
+	public abstract CodeableConcept getActivity();
 
 	protected void prepareBasicData(Provenance fhirResource, UriInfo context, HttpHeaders headers, String locationPath) throws Exception {
 
@@ -88,48 +90,59 @@ public abstract class ProvenanceResourceProxy {
 			Date currentDate = new Date();
 			fhirResource.setRecorded(currentDate);
 
+			fhirResource.setActivity(getActivity());
+
 			List<ProvenanceAgentComponent> agentList = new ArrayList<>();
-			//agentList.add(getAgent(headers, response));
 			agentList.add(getAgent(headers, location));
 			fhirResource.setAgent(agentList);
-			// TODO resourceType/resourceId
+	
 			fhirResource.getEntityFirstRep().setRole(ProvenanceEntityRole.SOURCE).setWhat(new Reference(locationStr));
+
 			// Signature
+			List<Signature> signatureList = new ArrayList<Signature>();
 			Signature signature = new Signature();
 			signature.setWhen(currentDate);
 			signature.setWho(new Reference(locationStr));
-			List<Signature> signatureList = new ArrayList<Signature>();
+			signatureList.add(signature);
 			fhirResource.setSignature(signatureList);
+
 			log.info("prepareBasicData");
 		}
 		catch (FHIRException e) {
-			log.severe(e.getMessage());
-			// e.printStackTrace();
+			e.printStackTrace();
+			throw e;
 		}
 
 	}
 
 	protected ProvenanceAgentComponent getAgent(HttpHeaders headers, URI location) throws Exception {
+
 		ProvenanceAgentComponent agent = new ProvenanceAgentComponent();
-		String userId = ServicesUtil.INSTANCE.getHttpHeader(headers, AuditEventConstant.HEADER_USER_ID);
+
 		String userName = ServicesUtil.INSTANCE.getHttpHeader(headers, AuditEventConstant.HEADER_USER_NAME);
-		if (StringUtils.isEmpty(userId)) {
-			userId = ProvenanceResourceProxy.userId;
-		}
-		agent.setUserData("userId", userId);
 		if (StringUtils.isEmpty(userName)) {
 			userName = ProvenanceResourceProxy.userName;
 		}
-		//URI location = response.getLocation();
-		String locationStr = "";
-		if (location != null) {
-			locationStr = location.toString();
-		}
+
+		CodeableConcept cc = new CodeableConcept();
+		Coding coding = new Coding();
+		coding.setSystem("http://terminology.hl7.org/CodeSystem/provenance-participant-type");
+		coding.setCode("performer");
+		cc.addCoding(coding);
+		agent.setType(cc);
+
+		cc = new CodeableConcept();
+		coding = new Coding();
+		coding.setSystem("http://dicom.nema.org/resources/ontology/DCM");
+		coding.setCode("110150");
+		coding.setDisplay("Application");
+		cc.addCoding(coding);
+
 		// who
 		Reference who = new Reference();
-		who.setDisplay(locationStr);
+		who.setDisplay(userName);
 		agent.setWho(who);
-		log.info("getAgent##" + agent.toString());
+
 		return agent;
 	}
 

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceResourceProxyObjectFactory.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceResourceProxyObjectFactory.java
@@ -53,8 +53,17 @@ public class ProvenanceResourceProxyObjectFactory {
 			if (ProvenanceActivityTypeEnum.CREATE.getCode() == operation) {
 				proxy = new ProvenanceCreateResource();
 			}
+			if (ProvenanceActivityTypeEnum.DELETE.getCode() == operation) {
+				proxy = new ProvenanceDeleteResource();
+			}
 			if (ProvenanceActivityTypeEnum.UPDATE.getCode() == operation) {
 				proxy = new ProvenanceUpdateResource();
+			}
+			if (ProvenanceActivityTypeEnum.APPEND.getCode() == operation) {
+				proxy = new ProvenanceAppendResource();
+			}
+			if (ProvenanceActivityTypeEnum.NULLIFY.getCode() == operation) {
+				proxy = new ProvenanceNullifyResource();
 			}
 
 		}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceService.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceService.java
@@ -32,29 +32,20 @@
  */
 package net.aegis.fhir.service.provenance;
 
-import java.io.ByteArrayInputStream;
-import java.util.Date;
 import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.transaction.UserTransaction;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
-
-import org.hl7.fhir.r4.formats.IParser.OutputStyle;
-import org.hl7.fhir.r4.formats.XmlParser;
-import org.hl7.fhir.r4.model.Meta;
+import javax.ws.rs.core.Response.Status;
 
 import net.aegis.fhir.model.Resource;
+import net.aegis.fhir.model.ResourceContainer;
 import net.aegis.fhir.service.CodeService;
 import net.aegis.fhir.service.ResourceService;
-import net.aegis.fhir.service.util.UUIDUtil;
 
 /**
  * @author Venkat.Keesara
@@ -68,81 +59,53 @@ public class ProvenanceService {
 
 	@Inject
 	CodeService codeService;
+
 	@Inject
 	ResourceService resourceService;
-
-	@PersistenceContext
-	private EntityManager em;
-
-	@javax.annotation.Resource
-	private UserTransaction userTransaction;
-	@Inject
-	private Event<net.aegis.fhir.model.Resource> resourceEventSrc;
 
 	/**
 	 * @param context
 	 * @param headers
 	 * @param payload
 	 * @param resourceType
-	 * @param response
-	 * @param string
+	 * @param locationPath
+	 * @param resourceId
+	 * @param operation
 	 * @throws Exception
 	 */
-	public void createProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) {
+	public void createProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception {
+
+		Resource resource = null;
+		ResourceContainer resCon = null;
+		String baseUrl = null;
 
 		try {
 			if (codeService.isSupported("provenanceServiceEnabled")) {
-				Resource resource = ProvenanceServiceUtil.INSTANCE.generateProvenance(context, headers, payload, resourceType, locationPath, resourceId, operation);
+				resource = ProvenanceServiceUtil.INSTANCE.generateProvenance(context, headers, payload, resourceType, locationPath, resourceId, operation);
 
-				String nextResourceIdString = UUIDUtil.getGUID();
-				;
-				int nextVersionId = 1;
-				Date updatedTime = new Date();
+				// Get server base url from code table configuration
+				baseUrl = codeService.getCodeValue("baseUrl");
 
-				// create a new wildfhir resource; version based on whether we came from an update or not
-				net.aegis.fhir.model.Resource newResource = new net.aegis.fhir.model.Resource();
-				newResource.setResourceId(nextResourceIdString);
-				newResource.setVersionId(Integer.valueOf(nextVersionId));
-				newResource.setResourceType(resource.getResourceType());
-				newResource.setStatus("valid");
-				newResource.setLastUser("system");
-				newResource.setLastUpdate(updatedTime);
+				resCon = resourceService.create(resource, null, baseUrl);
 
-				// Convert XML contents to Resource object and set id and meta
-				ByteArrayInputStream iResource = new ByteArrayInputStream(resource.getResourceContents());
-				XmlParser xmlP = new XmlParser();
-				xmlP.setOutputStyle(OutputStyle.PRETTY);
-				org.hl7.fhir.r4.model.Resource resourceObject = xmlP.parse(iResource);
-
-				resourceObject.setId(nextResourceIdString);
-
-				Meta resourceMeta = new Meta();
-				if (resourceObject.hasMeta()) {
-					resourceMeta = resourceObject.getMeta();
+				if (resCon.getResponseStatus().equals(Status.CREATED)) {
+					log.info("ProvenanceService.createProvenance() - Provenance/" + resCon.getResource().getResourceId() + " successfully created.");
 				}
-				resourceMeta.setVersionId(Integer.toString(nextVersionId));
-				resourceMeta.setLastUpdated(updatedTime);
-				resourceObject.setMeta(resourceMeta);
-				byte[] resourceBytes = xmlP.composeBytes(resourceObject);
-
-				newResource.setResourceContents(resourceBytes);
-
-				/*
-				 * TRANSACTION BEGIN
-				 */
-				userTransaction.begin();
-				em.persist(newResource);
-				resourceEventSrc.fire(newResource);
-
-				/*
-				 * TRANSACTION COMMIT(END)
-				 */
-				userTransaction.commit();
+				else {
+					throw new Exception("Error attempting to create Provenance! " +
+							resCon.getResponseStatus().getStatusCode() + " " + resCon.getResponseStatus().toString() + "" + (resCon.getMessage() != null ? resCon.getMessage() : ""));
+				}
 			}
 		}
 		catch (Exception e) {
-			log.severe(e.getMessage());
-			// e.printStackTrace();
+			e.printStackTrace();
+			throw e;
+		}
+		finally {
+			// Release resources for garbage collection
+			resource = null;
+			resCon = null;
+			baseUrl = null;
 		}
 
 	}

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceUpdateResource.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/provenance/ProvenanceUpdateResource.java
@@ -35,7 +35,8 @@ package net.aegis.fhir.service.provenance;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
-import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Provenance;
 import org.hl7.fhir.r4.model.Resource;
 
@@ -49,14 +50,21 @@ public class ProvenanceUpdateResource extends ProvenanceResourceProxy {
 	public Resource generateProvenance(UriInfo context, HttpHeaders headers, String payload, String resourceType, String locationPath, String resourceId, String operation) throws Exception {
 
 		Provenance fhirResource = new Provenance();
+
 		prepareBasicData(fhirResource, context, headers, locationPath);
 
 		return fhirResource;
 	}
 
 	@Override
-	public AuditEventAction setAction() {
-		return AuditEventAction.U;
+	public CodeableConcept getActivity() {
+		CodeableConcept activity = new CodeableConcept();
+		Coding activityCoding = new Coding();
+		activityCoding.setSystem(ProvenanceActivityTypeEnum.UPDATE.getSystem());
+		activityCoding.setCode(ProvenanceActivityTypeEnum.UPDATE.getCode());
+		activityCoding.setDisplay(ProvenanceActivityTypeEnum.UPDATE.getDisplay());
+		activity.addCoding(activityCoding);
+		return activity;
 	}
 
 }

--- a/source/wildfhir-service/src/main/java/net/aegis/fhir/service/util/ServicesUtil.java
+++ b/source/wildfhir-service/src/main/java/net/aegis/fhir/service/util/ServicesUtil.java
@@ -950,27 +950,33 @@ public enum ServicesUtil {
 	}
 
 	public String getHostName() {
-		String hostname = "localhost";
+		// Get hostname from environment variable WILDFHIR_HOSTNAME (defined in docker container)
+		String hostname = System.getenv("WILDFHIR_HOSTNAME");
 
-		try {
-			InetAddress addr = InetAddress.getLocalHost();
-			hostname = addr.getCanonicalHostName();
-		}
-		catch (Exception e) {
-			// Default to localhost if any exception thrown
+		if (hostname == null || hostname.isEmpty()) {
+			// WILDFHIR_HOSTNAME environment variable not defined; default to localhost
 			hostname = "localhost";
-		}
 
-		if (hostname.equals("localhost")) {
-			// InetAddress did not resolve; try OS hostname
 			try {
-				Process p = Runtime.getRuntime().exec("hostname");
-				byte[] bytes = p.getInputStream().readAllBytes();
-				hostname = new String(bytes,"ASCII").trim();
+				InetAddress addr = InetAddress.getLocalHost();
+				hostname = addr.getCanonicalHostName();
 			}
 			catch (Exception e) {
 				// Default to localhost if any exception thrown
 				hostname = "localhost";
+			}
+
+			if (hostname.equals("localhost")) {
+				// InetAddress did not resolve; try OS hostname
+				try {
+					Process p = Runtime.getRuntime().exec("hostname");
+					byte[] bytes = p.getInputStream().readAllBytes();
+					hostname = new String(bytes,"ASCII").trim();
+				}
+				catch (Exception e) {
+					// Default to localhost if any exception thrown
+					hostname = "localhost";
+				}
 			}
 		}
 


### PR DESCRIPTION
### What does this pull request do?
- Implement support for FAST Consent operations
  - $fileConsent, $updateConsent are operational
  - $recordDisclosure, $revokeConsent are stubbed and return not implement

- Update Docker Hub files to align with FAST Consent RI image repository

### Additional items
- AuditEvent and Provenance service updates
  - Add support for AuditEvent and Provenance services in operations
  - Set static info in AuditEvent and Provenance for FAST Consent RI
  - AuditEvent and Provenance services restructure and add proxy implementations for standard life cycle events

- Alignment with WildFHIR CE
  - getHostName now first checks for environment variable WILDFHIR_HOSTNAME
  - Include special code to handle ':identifier' modifier just prior to SQL generation